### PR TITLE
Make OAuth state enabled by default.

### DIFF
--- a/lib/passport-adobe-oauth2/strategy.js
+++ b/lib/passport-adobe-oauth2/strategy.js
@@ -64,6 +64,7 @@ function Strategy(options, verify) {
     opts.profileURL = opts.profileURL || opts.authorizationEndpoint + '/ims/profile/v1';
     opts.scopeSeparator = opts.scopeSeparator || ',';
     opts.customHeaders = opts.customHeaders || {};
+    opts.state = (options.state === undefined)?true:options.state;
     PassportOAuth.OAuth2Strategy.call(this, opts, verify);
     this.name = 'adobe';
     this._clientID = opts.clientID;


### PR DESCRIPTION
With state enabled by default there is less risk that someone using this library forgets to enable state. They can still disable it if required.